### PR TITLE
Add support for Go interfaces in type blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,37 @@
 {
     "name": "quick-implements",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quick-implements",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "devDependencies": {
-                "@types/node": "22.10.5",
-                "@types/vscode": "^1.96.0",
+                "@types/node": "22.13.1",
+                "@types/vscode": "^1.97.0",
                 "typescript": "^5.7.3"
             },
             "engines": {
-                "vscode": "^1.95.0"
+                "vscode": "^1.97.0"
             }
         },
         "node_modules/@types/node": {
-            "version": "22.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-            "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+            "version": "22.13.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+            "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
         },
         "node_modules/@types/vscode": {
-            "version": "1.96.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
-            "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
-            "dev": true
+            "version": "1.97.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.97.0.tgz",
+            "integrity": "sha512-ueE73loeOTe7olaVyqP9mrRI54kVPJifUPjblZo9fYcv1CuVLPOEKEkqW0GkqPC454+nCEoigLWnC2Pp7prZ9w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/typescript": {
             "version": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quick-implements",
     "displayName": "Quick Implements",
     "description": "Quickly view and navigate to interface/abstract class implementations with an inline indicator",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "folsom-sh",
     "icon": "images/icon.png",
     "repository": {
@@ -10,7 +10,7 @@
         "url": "https://github.com/ryanfolsom/vscode-quick-implements"
     },
     "engines": {
-        "vscode": "^1.95.0"
+        "vscode": "^1.97.0"
     },
     "categories": [
         "Programming Languages",
@@ -58,7 +58,7 @@
                 "quickImplements.interfacePatterns": {
                     "type": "object",
                     "default": {
-                        "go": "type\\s+(\\w+)\\s+interface\\s*{",
+                        "go": "(?:type\\s+|\\s+)(\\w+)\\s+interface\\s*{",
                         "java": "(interface|abstract\\s+class)\\s+(\\w+)",
                         "typescript": "(interface|abstract\\s+class)\\s+(\\w+)",
                         "csharp": "(interface|abstract\\s+class)\\s+(\\w+)",
@@ -81,8 +81,8 @@
         "watch": "tsc -watch -p ./"
     },
     "devDependencies": {
-        "@types/node": "22.10.5",
-        "@types/vscode": "^1.96.0",
+        "@types/node": "22.13.1",
+        "@types/vscode": "^1.97.0",
         "typescript": "^5.7.3"
     }
 }


### PR DESCRIPTION
This commit adds support for Go interfaces declared inside of `type` blocks.

Fixes #17 